### PR TITLE
feat: auto generate docs

### DIFF
--- a/.github/workflows/env-setup/action.yaml
+++ b/.github/workflows/env-setup/action.yaml
@@ -1,0 +1,16 @@
+name: "Rafiki Environment Setup"
+description: "Sets node version, init pnpm, restore cache"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 7
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'pnpm'
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -32,7 +32,7 @@ jobs:
               await github.rest.pulls.create({
                 owner: 'interledger',
                 repo: 'rafiki.dev',
-                body: `GraphQL schema updates have landed in [rafiki](https://github.com/interledger/rafiki), and docs have been generated from the updated schema. <br><br> *This PR was automatically opened by the `workflows/generate-docs.yaml` GitHub action.*`,
+                body: 'GraphQL schema updates have landed in [rafiki](https://github.com/interledger/rafiki), and docs have been generated from the updated schema. <br><br> *This PR was automatically opened by the `workflows/generate-docs.yaml` GitHub action.*',
                 title: 'Generate docs from updated schema',
                 head: 'bot/generate-docs-from-updated-schema',
                 base: 'main'

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -10,30 +10,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/env-setup
       - run: pnpm docs:graphql:generate
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: peter-evans/create-pull-request@v4
         with:
-          commit_message: "[Bot] Generate docs from updated GraphQL schema"
-          push_options: "--force"
+          commit-message: "[Bot] Generate docs from updated GraphQL schema"
           branch: bot/generate-docs-from-updated-schema
-
-      - name: Open PR with updated changes
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const listOfPRs = await github.rest.pulls.list({
-              owner: 'interledger',
-              repo: 'rafiki.dev',
-              head: 'interledger:bot/generate-docs-from-updated-schema',
-              state: 'open'
-            });
-
-            if (listOfPRs.data.length === 0) {
-              await github.rest.pulls.create({
-                owner: 'interledger',
-                repo: 'rafiki.dev',
-                body: `GraphQL schema updates have landed in [rafiki](https://github.com/interledger/rafiki), and docs have been generated from the updated schema. <br><br> *This PR was automatically opened by the `workflows/generate-docs.yaml` GitHub action.*`,
-                title: 'Generate docs from updated schema',
-                head: 'bot/generate-docs-from-updated-schema',
-                base: 'main'
-              });
-            }
+          body: `GraphQL schema updates have landed in [rafiki](https://github.com/interledger/rafiki), and docs have been generated from the updated schema. <br><br> *This PR was automatically opened by the `workflows/generate-docs.yaml` GitHub action.*`,
+          title: 'Generate docs from updated schema'

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -10,9 +10,30 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/env-setup
       - run: pnpm docs:graphql:generate
-      - uses: peter-evans/create-pull-request@v4
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit-message: "[Bot] Generate docs from updated GraphQL schema"
+          commit_message: "[Bot] Generate docs from updated GraphQL schema"
+          push_options: "--force"
           branch: bot/generate-docs-from-updated-schema
-          body: `GraphQL schema updates have landed in [rafiki](https://github.com/interledger/rafiki), and docs have been generated from the updated schema. <br><br> *This PR was automatically opened by the `workflows/generate-docs.yaml` GitHub action.*`,
-          title: 'Generate docs from updated schema'
+
+      - name: Open PR with updated changes
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const listOfPRs = await github.rest.pulls.list({
+              owner: 'interledger',
+              repo: 'rafiki.dev',
+              head: 'interledger:bot/generate-docs-from-updated-schema',
+              state: 'open'
+            });
+
+            if (listOfPRs.data.length === 0) {
+              await github.rest.pulls.create({
+                owner: 'interledger',
+                repo: 'rafiki.dev',
+                body: `GraphQL schema updates have landed in [rafiki](https://github.com/interledger/rafiki), and docs have been generated from the updated schema. <br><br> *This PR was automatically opened by the `workflows/generate-docs.yaml` GitHub action.*`,
+                title: 'Generate docs from updated schema',
+                head: 'bot/generate-docs-from-updated-schema',
+                base: 'main'
+              });
+            }

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -15,6 +15,7 @@ jobs:
           commit_message: "[Bot] Generate docs from updated GraphQL schema"
           push_options: "--force"
           branch: bot/generate-docs-from-updated-schema
+          create_branch: true
 
       - name: Open PR with updated changes
         uses: actions/github-script@v5

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,39 @@
+name: "Generate docs from updated GraphQL schema"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-docs-from-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/env-setup
+      - run: pnpm docs:graphql:generate
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[Bot] Generate docs from updated GraphQL schema"
+          push_options: "--force"
+          branch: bot/generate-docs-from-updated-schema
+
+      - name: Open PR with updated changes
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const listOfPRs = await github.rest.pulls.list({
+              owner: 'interledger',
+              repo: 'rafiki.dev',
+              head: 'interledger:bot/generate-docs-from-updated-schema',
+              state: 'open'
+            });
+
+            if (listOfPRs.data.length === 0) {
+              await github.rest.pulls.create({
+                owner: 'interledger',
+                repo: 'rafiki.dev',
+                body: 'Testing',
+                title: 'Generate docs from updated schema',
+                head: 'bot/generate-docs-from-updated-schema',
+                base: 'main'
+              });
+            }

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -31,7 +31,7 @@ jobs:
               await github.rest.pulls.create({
                 owner: 'interledger',
                 repo: 'rafiki.dev',
-                body: 'Testing',
+                body: `GraphQL schema updates have landed in [rafiki](https://github.com/interledger/rafiki), and docs have been generated from the updated schema. <br><br> *This PR was automatically opened by the `workflows/generate-docs.yaml` GitHub action.*`,
                 title: 'Generate docs from updated schema',
                 head: 'bot/generate-docs-from-updated-schema',
                 base: 'main'


### PR DESCRIPTION
This PR adds an action to auto generate documentation and open PR when changes to the admin GraphQL schema have been pushed to `main` rafiki. This action would get triggered on the Rafiki side via another action:
- https://github.com/interledger/rafiki/pull/1286

Example PR:
- https://github.com/interledger/rafiki.dev/pull/18

Example action consumed by rafiki.dev:
- https://github.com/interledger/rafiki.dev/actions/runs/4564588204